### PR TITLE
Patch: Move the setBody = ${exchangeProperty.sanitizedBody} into the regex replacement choice block

### DIFF
--- a/templates/webhook-to-tcp/2.8/webhook-to-tcp~2.8.yml
+++ b/templates/webhook-to-tcp/2.8/webhook-to-tcp~2.8.yml
@@ -1408,10 +1408,10 @@ shared:
                           def regexReplacement = regexListItem.get("replacement")
 
                           return currentBody.replaceAll(regexPattern, regexReplacement)
-        - method: setBody
-          expression:
-            type: "simple"
-            expression: "${exchangeProperty.sanitizedBody}"
+                    - method: setBody
+                      expression:
+                        type: "simple"
+                        expression: "${exchangeProperty.sanitizedBody}"
         # REF-4IZ - Data decoding
         - method: choice
           when:


### PR DESCRIPTION
Currently, we're setting it outside of the regex replacement choice block, meaning that if the user hasn't defined any regex replacement, they will get an error stating that the body is null